### PR TITLE
fix ghc:8.4 build on rhel7 aarch64

### DIFF
--- a/ghc-Stg.h.patch
+++ b/ghc-Stg.h.patch
@@ -1,0 +1,12 @@
+diff -ur ghc-8.4.4.orig/includes/Stg.h ghc-8.4.4/includes/Stg.h
+--- ghc-8.4.4.orig/includes/Stg.h	2018-01-29 21:20:01.000000000 +0000
++++ ghc-8.4.4/includes/Stg.h	2021-04-01 23:19:51.741788378 +0100
+@@ -236,6 +236,8 @@
+ #define EB_(X)    extern const char X[]
+ #define IB_(X)    static const char X[]
+ /* static (non-heap) closures (requires alignment for pointer tagging): */
++#define EI_(X)    extern       StgWordArray (X) GNU_ATTRIBUTE(aligned (8))
++#define II_(X)    static       StgWordArray (X) GNU_ATTRIBUTE(aligned (8))
+ #define EC_(X)    extern       StgWordArray (X) GNU_ATTRIBUTE(aligned (8))
+ #define IC_(X)    static       StgWordArray (X) GNU_ATTRIBUTE(aligned (8))
+ /* writable data (does not require alignment): */

--- a/ghc.spec
+++ b/ghc.spec
@@ -71,6 +71,7 @@ Patch24: buildpath-abi-stability.patch
 Patch26: no-missing-haddock-file-warning.patch
 Patch28: x32-use-native-x86_64-insn.patch
 Patch30: fix-build-using-unregisterized-v8.2.patch
+Patch35: ghc-Stg.h.patch
 
 # fedora ghc has been bootstrapped on
 # %%{ix86} x86_64 ppc ppc64 armv7hl s390 s390x ppc64le aarch64
@@ -624,6 +625,10 @@ fi
 
 
 %changelog
+* Fri Apr 2 2021 Andriy Tkachuk <andriy.tkachuk@seagate.com>
+- add ghc-Stg.h.patch to fix the build issue on rhel7 aarch64,
+  see https://gitlab.haskell.org/ghc/ghc/-/issues/15201
+
 * Sun Nov 18 2018 Zbigniew Jędrzejewski-Szmek <zbyszek@in.waw.pl>
 - Use C.UTF-8 locale
   See https://fedoraproject.org/wiki/Changes/Remove_glibc-langpacks-all_from_buildroot


### PR DESCRIPTION
The issue similar to
https://gitlab.haskell.org/ghc/ghc/-/issues/15201 is fixed
by adding the old EI_ and II_ macros to includes/Stg.h from
ghc-8.0/8.2.

Tested on CentOS-7.9 aarch64 with ghc-8.0.2.