### PR TITLE
ghc.spec: fix llvm_major version on rhel7

### DIFF
--- a/ghc.spec
+++ b/ghc.spec
@@ -26,6 +26,13 @@
 %global llvm_major 6.0
 %global ghc_llvm_archs armv7hl aarch64
 
+%ifarch %{ghc_llvm_archs}
+%if 0%{?rhel} == 7
+# there is no llvm6.0 on rhel7, but there is llvm7.0
+%global llvm_major 7.0
+%endif
+%endif
+
 %global ghc_unregisterized_arches s390 s390x %{mips}
 
 Name: ghc
@@ -80,6 +87,10 @@ Patch24: buildpath-abi-stability.patch
 Patch26: no-missing-haddock-file-warning.patch
 Patch28: x32-use-native-x86_64-insn.patch
 
+# for rhel7 on aarch64
+Patch33: llvm7.0-el7-arm64.patch
+
+
 # fedora ghc has been bootstrapped on
 # %%{ix86} x86_64 ppc ppc64 armv7hl s390 s390x ppc64le aarch64
 # and retired arches: alpha sparcv9 armv5tel
@@ -108,7 +119,7 @@ BuildRequires: python3
 BuildRequires: python-sphinx
 %endif
 %ifarch %{ghc_llvm_archs}
-%if 0%{?fedora} >= 29
+%if 0%{?fedora} >= 29 || 0%{?rhel} == 7
 BuildRequires: llvm%{llvm_major}
 %else
 BuildRequires: llvm >= %{llvm_major}
@@ -168,7 +179,7 @@ Obsoletes: ghc-doc-cron < %{version}-%{release}
 Obsoletes: ghc-doc-index < %{version}-%{release}
 %endif
 %ifarch %{ghc_llvm_archs}
-%if 0%{?fedora} >= 29
+%if 0%{?fedora} >= 29 || 0%{?rhel} == 7
 Requires: llvm%{llvm_major}
 %else
 Requires: llvm >= %{llvm_major}
@@ -309,6 +320,11 @@ rm -r libffi-tarballs
 %patch24 -p1 -b .orig
 %patch26 -p1 -b .orig
 %patch28 -p1 -b .orig
+
+# update LlvmVersion
+%if "%{llvm_major}" == "7.0"
+%patch33 -p1 -b .orig
+%endif
 
 %global gen_contents_index gen_contents_index.orig
 %if %{with docs}

--- a/llvm7.0-el7-arm64.patch
+++ b/llvm7.0-el7-arm64.patch
@@ -1,0 +1,24 @@
+diff -ur ghc-8.6.5.orig/configure ghc-8.6.5/configure
+--- ghc-8.6.5.orig/configure	2019-04-24 05:31:47.000000000 +0100
++++ ghc-8.6.5/configure	2021-04-03 19:49:48.142052067 +0100
+@@ -8709,7 +8709,7 @@
+ # tools we are looking for. In the past, GHC supported a number of
+ # versions of LLVM simultaneously, but that stopped working around
+ # 3.5/3.6 release of LLVM.
+-LlvmVersion=6.0
++LlvmVersion=7.0
+ 
+ sUPPORTED_LLVM_VERSION=$(echo \($LlvmVersion\) | sed 's/\./,/')
+ 
+diff -ur ghc-8.6.5.orig/configure.ac ghc-8.6.5/configure.ac
+--- ghc-8.6.5.orig/configure.ac	2019-04-23 02:46:43.000000000 +0100
++++ ghc-8.6.5/configure.ac	2021-04-03 19:47:15.661842415 +0100
+@@ -648,7 +648,7 @@
+ # tools we are looking for. In the past, GHC supported a number of
+ # versions of LLVM simultaneously, but that stopped working around
+ # 3.5/3.6 release of LLVM.
+-LlvmVersion=6.0
++LlvmVersion=7.0
+ AC_SUBST([LlvmVersion])
+ sUPPORTED_LLVM_VERSION=$(echo \($LlvmVersion\) | sed 's/\./,/')
+ AC_DEFINE_UNQUOTED([sUPPORTED_LLVM_VERSION], ${sUPPORTED_LLVM_VERSION}, [The supported LLVM version number])


### PR DESCRIPTION
On rhel7 (CentOS-7.9 variant) there is no llvm6.0 package, but there is llvm7.0 in epel, so use it instead.